### PR TITLE
Fix: Resolve 404 error when fetching notebook list

### DIFF
--- a/backend/routers/notebooks.py
+++ b/backend/routers/notebooks.py
@@ -4,7 +4,6 @@ from .. import crud, models, ai_services # Use relative imports
 import os
 
 router = APIRouter(
-    prefix="/api/notebooks",
     tags=["notebooks"],
 )
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -120,7 +120,7 @@ export const uploadMultiplePdfs = async (
 
 // 추가적인 인터페이스 정의
 export interface Notebook {
-  id: number;
+  id: string;
   title: string;
   // 백엔드 모델에 따라 필드를 추가/수정하세요.
   // 예: created_at: string;


### PR DESCRIPTION
The main page was failing to load the notebook list due to a 404 error. This was caused by a duplicated API prefix in the backend routing configuration. The '/api/notebooks' prefix was defined both in the APIRouter instance in `backend/routers/notebooks.py` and when including the router in `backend/main.py`, leading to an effective endpoint path of `/api/notebooks/api/notebooks` instead of the expected `/api/notebooks`.

This commit corrects the issue by removing the prefix from the `APIRouter` definition in `backend/routers/notebooks.py`, as `backend/main.py` already correctly specifies the `/api/notebooks` prefix when including the router.

Additionally, this commit addresses a type mismatch for the notebook 'id' field. The frontend interface `Notebook` in `frontend/src/services/api.ts` expected 'id' as a number, while the backend serves it as a string. The interface has been updated to expect 'id: string' to align with the backend data, preventing potential data handling errors in the frontend.