### PR TITLE
Fix: Resolve errors in AI content generation pipeline

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -32,7 +32,7 @@ class ImportantTerm(BaseModel):
     definition: str
 
 class OutlineItem(BaseModel):
-    title: str
+    text: str # Changed from title
     id: str
     children: Optional[List['OutlineItem']] = None # Recursive
 
@@ -41,7 +41,7 @@ OutlineItem.update_forward_refs() # For recursive model
 class AINotes(BaseModel):
     summary: str
     keyConcepts: List[KeyConcept]
-    importantTerms: List[ImportantTerm]
+    importantTerms: List[Union[ImportantTerm, str]] # Changed line
     outline: List[OutlineItem]
 
 # For Quiz


### PR DESCRIPTION
This commit addresses several errors that occurred during the AI-driven content generation process when processing uploaded PDFs:

1.  **AttributeError for QuizItem**:
    - I corrected a typo in `backend/ai_services.py` by changing `models.QuizItem` to `models.QuizQuestion`, ensuring the quiz generation logic uses the correctly defined Pydantic model.

2.  **Improved parsing of `important_terms`**:
    - I modified the `AINotes` Pydantic model in `backend/models.py` to define `importantTerms` as `List[Union[ImportantTerm, str]]`. This allows for more flexible initial parsing of LLM output where some terms might be simple strings.
    - I added a data cleaning step in `backend/ai_services.py` (within `generate_content_for_chapter`) to iterate through the parsed `important_terms` list. This step converts any string elements into structured `ImportantTerm` objects with a placeholder definition, ensuring data consistency before final Pydantic model instantiation. This makes the system more resilient to variations in LLM output for this field.

3.  **Aligned `OutlineItem` model with LLM output**:
    - I updated the `OutlineItem` Pydantic model in `backend/models.py` by changing the field `title: str` to `text: str`. This aligns the model with the "text" field name used by the LLM for outline items, preventing validation errors.

These changes enhance the robustness and correctness of the AI content generation pipeline, reducing failures due to model mismatches or variations in LLM output format.