### PR TITLE
Fix chapter game button

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -107,12 +107,17 @@ def get_document_content(db: Session, notebook_id: int, chapter_order: int) -> O
 
     if content and content.data:
         # The transformation logic for 'aiNotes' can be applied here if still needed
-        content_data = content.data
+        content_data = dict(content.data)
         if 'aiNotes' in content_data and isinstance(content_data['aiNotes'], dict) and \
            'outline' in content_data['aiNotes'] and isinstance(content_data['aiNotes']['outline'], list):
             for item in content_data['aiNotes']['outline']:
                 if isinstance(item, dict):
                     _transform_outline_item(item)
+
+        # Include game_html from the related chapter
+        game_html = content.chapter.game_html if content.chapter else None
+        content_data['game_html'] = game_html
+
         try:
             return models.DocumentContent(**content_data)
         except Exception as e:

--- a/backend/models.py
+++ b/backend/models.py
@@ -140,6 +140,7 @@ class DocumentContent(BaseModel):
     documentContent: List[Dict[str, Any]] = Field(..., description="A list of content blocks, where each block is a dictionary with 'type', 'content', and optional 'level'.")
     aiNotes: AINotes
     quiz: List[QuizQuestion]
+    game_html: Optional[str] = None
 
 # For File Structure
 class FileStructureItem(BaseModel):

--- a/backend/routers/notebooks.py
+++ b/backend/routers/notebooks.py
@@ -185,7 +185,7 @@ async def generate_chapter_game(chapter_id: int, db: Session = Depends(get_db)):
         # This case should be rare if the initial chapter fetch succeeded
         raise HTTPException(status_code=500, detail="Failed to save the generated game to the database.")
 
-    return updated_chapter
+    return {"message": "Game generated successfully", "game_html": updated_chapter.game_html}
 
 
 @router.post("/{notebook_id}/upload-and-create-chapter",

--- a/backend/tests/test_notebooks.py
+++ b/backend/tests/test_notebooks.py
@@ -118,7 +118,11 @@ def test_generate_game_for_chapter(client: TestClient, db_session: Session):
     # Then: Assert the response and the database state
     assert response.status_code == 200, response.text
 
+    data = response.json()
+    assert "game_html" in data and data["game_html"]
+
     db_session.refresh(chapter)
     assert chapter.game_html is not None
+    assert chapter.game_html == data["game_html"]
     # Check for either doctype or html tag to be more robust
     assert "<!doctype html>" in chapter.game_html.lower() or "<html>" in chapter.game_html.lower()

--- a/frontend/src/components/workspace/DocumentViewer.tsx
+++ b/frontend/src/components/workspace/DocumentViewer.tsx
@@ -89,8 +89,8 @@ const DocumentViewer = ({ notebookId, selectedChapter, documentData, fileStructu
 
     if (notebookId && selectedChapter) {
       // selectedChapter 문자열에서 챕터 번호(첫 번째 숫자) 추출
-      // 예: "1. 행렬과 연립방정식" -> "1" 추출
-      const chapterNumberMatch = selectedChapter.match(/^(\d+)\./);
+      // "1" 또는 "1. 행렬과 연립방정식" 모두 지원
+      const chapterNumberMatch = selectedChapter.match(/^(\d+)/);
 
       if (chapterNumberMatch && chapterNumberMatch[1]) {
         const chapterNumber = chapterNumberMatch[1];
@@ -184,7 +184,8 @@ const DocumentViewer = ({ notebookId, selectedChapter, documentData, fileStructu
     }
 
     // selectedChapter에서 chapterId(숫자) 추출
-    const chapterIdMatch = selectedChapter.match(/^(\d+)\./);
+    // "1" 또는 "1. 챕터 제목" 형식 모두 허용
+    const chapterIdMatch = selectedChapter.match(/^(\d+)/);
     if (!chapterIdMatch) {
       toast.error("유효한 챕터 ID를 찾을 수 없습니다.");
       return;

--- a/frontend/src/pages/Workspace.tsx
+++ b/frontend/src/pages/Workspace.tsx
@@ -34,6 +34,7 @@ interface DocumentContent {
     answerIndex: number;
     explanation: string;
   }>;
+  game_html?: string;
 }
 
 // Sidebar에 필요한 파일 구조 타입. Chapter 데이터를 이 형태로 변환합니다.
@@ -98,13 +99,16 @@ const Workspace = () => {
                 getChapterContent(notebookId, targetChapterId),
                 getChapterStructure(notebookId, targetChapterId)
             ]);
-            
+
+            const chapterInfo = chaptersResponse.find(ch => ch.id.toString() === targetChapterId);
+
             const transformedData: DocumentContent = {
                 title: contentData.title || '제목 없음',
                 metadata: contentData.metadata || '',
                 documentContent: structureData.nodes || [],
                 aiNotes: contentData.aiNotes || { summary: '', keyConcepts: [], importantTerms: [], outline: [] },
                 quiz: contentData.quiz || [],
+                game_html: chapterInfo?.game_html || contentData.game_html,
                 ...contentData,
             };
             setDocumentData(transformedData);


### PR DESCRIPTION
## Summary
- include `game_html` when fetching chapter content
- send simple message+HTML from `generate_chapter_game`
- pass existing `game_html` from chapters to `DocumentViewer`
- adjust tests for new response shape

## Testing
- `pytest -q` *(fails: DefaultCredentialsError from Google Auth)*

------
https://chatgpt.com/codex/tasks/task_e_684d110d3ae4832a83f41a554e77786c